### PR TITLE
Fix broken image endpoints

### DIFF
--- a/app.py
+++ b/app.py
@@ -175,7 +175,21 @@ def save_file_locally(file, folder, filename):
                     
                     # Resize if too large
                     img.thumbnail((800, 800), Image.Resampling.LANCZOS)
-                    img.save(file_path, 'JPEG', quality=85, optimize=True)
+
+                    # Save as optimized JPEG and update filename to .jpg
+                    base_name, _ext = os.path.splitext(filename)
+                    optimized_filename = base_name + '.jpg'
+                    optimized_path = os.path.join(folder_path, optimized_filename)
+                    img.save(optimized_path, 'JPEG', quality=85, optimize=True)
+
+                    # Remove original if different
+                    if optimized_path != file_path and os.path.exists(file_path):
+                        try:
+                            os.remove(file_path)
+                        except Exception:
+                            pass
+
+                    filename = optimized_filename
             except Exception as img_error:
                 print(f"Image optimization error: {str(img_error)}")
         

--- a/templates/found.html
+++ b/templates/found.html
@@ -21,7 +21,7 @@
                                          class="img-fluid rounded" alt="{{ child.name }}">
                                 {% else %}
                                     <!-- Local file -->
-                                    <img src="{{ url_for('static', filename=child.photo_filename) }}" 
+                                    <img src="{{ url_for('static', filename='uploads/photos/' + child.photo_filename) }}" 
                                          class="img-fluid rounded" alt="{{ child.name }}">
                                 {% endif %}
                             {% else %}
@@ -49,7 +49,7 @@
                                 {% else %}
                                     <!-- Local file -->
                                     <audio controls class="w-100">
-                                        <source src="{{ url_for('static', filename=child.audio_filename) }}" type="audio/mpeg">
+                                        <source src="{{ url_for('static', filename='uploads/audio/' + child.audio_filename) }}" type="audio/mpeg">
                                         Your browser does not support the audio element.
                                     </audio>
                                 {% endif %}


### PR DESCRIPTION
Fix image and audio display by ensuring optimized images are saved as `.jpg` and correcting static file paths in `found.html`.

Images were not displaying because `save_file_locally` was not consistently saving optimized images with a `.jpg` extension, and `found.html` was referencing local static files without the necessary `uploads/photos/` and `uploads/audio/` prefixes in their URLs.

---
<a href="https://cursor.com/background-agent?bcId=bc-436f709f-ab91-4da1-9a0e-fa972d861b6f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-436f709f-ab91-4da1-9a0e-fa972d861b6f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

