### PR TITLE
Add horizontal scroll to mobile admin table

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -404,6 +404,11 @@ main.container {
     vertical-align: middle;
 }
 
+/* Ensure tables are wide enough to trigger horizontal scroll on mobile */
+.admin-table-scroll table {
+    min-width: 700px;
+}
+
 .table-striped > tbody > tr:nth-of-type(odd) > td {
     background: rgba(231, 76, 60, 0.02);
 }
@@ -652,7 +657,10 @@ input[type="checkbox"] {
 
 /* Ensure no overlays are blocking */
 .table-responsive {
-    overflow: visible !important;
+    overflow-x: auto !important;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    display: block;
 }
 
 .card-body {

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -52,7 +52,7 @@
     </div>
     <div class="card-body">
         <form id="bulkDeleteForm" method="POST" action="{{ url_for('bulk_delete_cases') }}">
-            <div class="table-responsive">
+            <div class="table-responsive admin-table-scroll">
                 <table class="table table-striped">
                     <thead>
                         <tr>
@@ -371,9 +371,11 @@ input[type="checkbox"] {
     z-index: 10 !important;
 }
 
-/* Ensure no overlays are blocking */
+/* Ensure responsive table scrolls horizontally on small screens */
 .table-responsive {
-    overflow: visible !important;
+    overflow-x: auto !important;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
 }
 
 .card-body {


### PR DESCRIPTION
Re-enable horizontal scrolling for admin tables on mobile to ensure the full content is visible.

---
<a href="https://cursor.com/background-agent?bcId=bc-2b4f3156-ec90-4aaa-9ad7-7d01a4a8ea25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2b4f3156-ec90-4aaa-9ad7-7d01a4a8ea25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

